### PR TITLE
#154 이미 최신 버전인 경우에는 옵션 메뉴 비활성화.

### DIFF
--- a/.github/workflows/generate-coverage-reports.yml
+++ b/.github/workflows/generate-coverage-reports.yml
@@ -7,7 +7,7 @@ on:
       - main
 jobs:
   generate-coverage-reports:
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     steps:
       - name: 소스코드 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/generate-coverage-reports.yml
+++ b/.github/workflows/generate-coverage-reports.yml
@@ -7,7 +7,7 @@ on:
       - main
 jobs:
   generate-coverage-reports:
-    runs-on: macos-latest-xlarge
+    runs-on: macos-latest
     steps:
       - name: 소스코드 Checkout
         uses: actions/checkout@v3
@@ -41,9 +41,10 @@ jobs:
       - name: 계측 테스트 코드 실행
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: arm64-v8a
-          target: google_apis
+#          api-level: 30
+#          arch: arm64-v8a
+#          target: google_apis
+          api-level: 29
           script: ./gradlew clean :app:generateMultiModuleCodeCoverageReports
       - name: 계측 테스트 리포트 생성
         uses: actions/upload-artifact@v3

--- a/app/src/main/java/kr/co/hs/sudoku/feature/MainActivity.kt
+++ b/app/src/main/java/kr/co/hs/sudoku/feature/MainActivity.kt
@@ -326,14 +326,18 @@ class MainActivity : Activity(), NavigationBarView.OnItemSelectedListener {
         menu?.findItem(R.id.enabled_cell_haptic)?.isChecked =
             gameSettingsViewModel.gameSettings.value?.enabledHapticFeedback == true
 
-        menu?.findItem(R.id.version_info)?.title = packageManager.runCatching {
-            val packageInfo = getPackageInfo(packageName, PackageManager.GET_META_DATA)
+        menu?.findItem(R.id.version_info)?.let { menuItem ->
+            val versionName = packageManager.runCatching {
+                getPackageInfo(packageName, PackageManager.GET_META_DATA).versionName
+            }.getOrNull()
             if (hasUpdate) {
-                getString(R.string.version_updatable_format, packageInfo.versionName)
+                menuItem.title = getString(R.string.version_updatable_format, versionName)
+                menuItem.isEnabled = true
             } else {
-                getString(R.string.version_format, packageInfo.versionName)
+                menuItem.title = getString(R.string.version_format, versionName)
+                menuItem.isEnabled = false
             }
-        }.getOrDefault("")
+        }
 
         return super.onCreateOptionsMenu(menu)
     }
@@ -368,7 +372,7 @@ class MainActivity : Activity(), NavigationBarView.OnItemSelectedListener {
                 true
             }
 
-            R.id.version_info -> {
+            R.id.version_info -> if (hasUpdate) {
                 lifecycleScope.launch(CoroutineExceptionHandler { _, throwable ->
                     dismissProgressIndicator()
                     throwable.showErrorAlert()
@@ -377,6 +381,8 @@ class MainActivity : Activity(), NavigationBarView.OnItemSelectedListener {
                     doUpdate()
                 }
                 true
+            } else {
+                false
             }
 
             else -> super.onOptionsItemSelected(item)


### PR DESCRIPTION
- 추가로 coverage-reports 생성 workflow가 sillicon mac에서 동작하도록 runs-on을 macos-latest-xlarge 으로 변경