### PR TITLE
#183 도전 관리에서 도전 생성 직후 FireStore에서 생성되는 createAt timestamp값이 null이어서 조…

### DIFF
--- a/app/src/main/java/kr/co/hs/sudoku/feature/admin/ChallengeManageViewModel.kt
+++ b/app/src/main/java/kr/co/hs/sudoku/feature/admin/ChallengeManageViewModel.kt
@@ -91,13 +91,11 @@ class ChallengeManageViewModel(
             matrix = matrix
         )
 
-        val isSuccess =
-            withContext(Dispatchers.IO) { ChallengeRepositoryImpl().createChallenge(entity) }
-
+        val challengeRepository = ChallengeRepositoryImpl()
+        val isSuccess = withContext(Dispatchers.IO) { challengeRepository.createChallenge(entity) }
         setProgress(false)
-
         if (isSuccess) {
-            onComplete(entity)
+            onComplete(withContext(Dispatchers.IO) { challengeRepository.getChallenge(entity.challengeId) })
         } else {
             throw Exception("create failed")
         }


### PR DESCRIPTION
…건으로 인해 푸쉬 전송이 안되는 문제가 있어서 생성 직후 FireStore에서 값을 다시 가져와서 푸쉬를 전송하도록 수정함.